### PR TITLE
Potential README typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ formData.append('title', 'Hello world!');
 const createdRecord = await client.Records.create('example', formData);
 ```
 
-### Errors handling
+### Error handling
 
 All services return a standard [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)-based response, so the error handling is straightforward:
 ```js


### PR DESCRIPTION
I'm quite sure this title should be a singular 'Error handling' or alternatively 'Errors'. The same potential typo is on the Dart SDK side as well.

(I'm not a native speaker though, some samples from other places with this singular form:
https://expressjs.com/en/guide/error-handling.html
https://en.wikipedia.org/wiki/Exception_handling)

I found this project today, definitely trying this out!