### PR TITLE
BaseAuthStore.onChange enhancements

### DIFF
--- a/src/stores/BaseAuthStore.ts
+++ b/src/stores/BaseAuthStore.ts
@@ -5,10 +5,6 @@ import Admin from '@/models/Admin';
 
 type onChangeFunc = (token: string, model: User|Admin|null) => void;
 
-export type AuthOnChangeOptions = {
-    fireImmediately: boolean
-}
-
 const defaultCookieKey = 'pb_auth';
 
 /**
@@ -147,10 +143,7 @@ export default abstract class BaseAuthStore {
      *
      * Returns a removal function that you could call to "unsubscribe" from the changes.
      */
-    onChange(callback: onChangeFunc, options?: Partial<AuthOnChangeOptions>): () => void {
-        const _options:AuthOnChangeOptions = { fireImmediately: true, ...options }
-        const {fireImmediately} = _options
-        
+    onChange(callback: onChangeFunc, fireImmediately = false): () => void {
         this._onChangeCallbacks.push(callback);
         if (fireImmediately) {
             callback(this.token,this.model)

--- a/src/stores/BaseAuthStore.ts
+++ b/src/stores/BaseAuthStore.ts
@@ -5,6 +5,10 @@ import Admin from '@/models/Admin';
 
 type onChangeFunc = (token: string, model: User|Admin|null) => void;
 
+export type AuthOnChangeOptions = {
+    fireImmediately: boolean
+}
+
 const defaultCookieKey = 'pb_auth';
 
 /**
@@ -143,8 +147,14 @@ export default abstract class BaseAuthStore {
      *
      * Returns a removal function that you could call to "unsubscribe" from the changes.
      */
-    onChange(callback: () => void): () => void {
+    onChange(callback: onChangeFunc, options?: Partial<AuthOnChangeOptions>): () => void {
+        const _options:AuthOnChangeOptions = { fireImmediately: true, ...options }
+        const {fireImmediately} = _options
+        
         this._onChangeCallbacks.push(callback);
+        if (fireImmediately) {
+            callback(this.token,this.model)
+        }
 
         return () => {
             for (let i = this._onChangeCallbacks.length - 1; i >= 0; i--) {


### PR DESCRIPTION
* use `onChangeFunc` type for `onChange()` callback param
* introduce an options param with `fireImmediately` defaulting to `true` so the auth state callback will fire immediately with the initial state. This adjustment makes client code slightly more DRY.