### PR TITLE
extend Record type for custom type definitions for records

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ To manually cancel pending requests, you could use `pb.cancelAllRequests()` or `
 You could specify custom TypeScript definitions for your Record models using generics:
 
 ```ts
-interface Task {
+interface Task extends Record {
   // type the collection fields you want to use...
   id:   string;
   name: string;


### PR DESCRIPTION
fix #87 by updating the `README.md` with extended interface.