### PR TITLE
Update link to API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const adminData = await pb.admins.authWithPassword('test@example.com', '123456')
 
 // and much more...
 ```
-> More detailed API docs and copy-paste examples could be found in the [API documentation for each service](https://pocketbase.io/docs/api-authentication).
+> More detailed API docs and copy-paste examples could be found in the [API documentation for each service](https://pocketbase.io/docs/api-records/).
 
 
 ## Caveats


### PR DESCRIPTION
The [Usage section](https://github.com/pocketbase/js-sdk#usage) of this repo's README ends with "more detailed API docs and copy-paste examples could be found in the [API documentation for each service](https://pocketbase.io/docs/api-authentication)."

Why does "API documentation" link to the Authentication page? It's hard to find docs for fetching records, subscribing to collections, etc. because their code examples are buried under "Web APIs".

What if we link to the Web APIs section instead? https://pocketbase.io/docs/api-records/

The Web API pages document everything you can do with PocketBase and include code samples for JavaScript and Dart.