### PR TITLE
fix: allow async functions in beforeSend and afterSend

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -247,7 +247,7 @@ export default class Client {
         }
 
         if (this.beforeSend) {
-            const result = Object.assign({}, this.beforeSend(url, options));
+            const result = Object.assign({}, await this.beforeSend(url, options));
             if (typeof result.url !== "undefined" || typeof result.options !== "undefined") {
                 url = result.url || url;
                 options = result.options || options;
@@ -271,7 +271,7 @@ export default class Client {
                 }
 
                 if (this.afterSend) {
-                    data = this.afterSend(response, data);
+                    data = await this.afterSend(response, data);
                 }
 
                 if (response.status >= 400) {


### PR DESCRIPTION
This patch allows async functions to be in beforeSend and afterSend to be executed correctly. Sync functions aren't affected because await [works for sync functions too](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#description). 