### PR TITLE
feat: add extraOptions on Record

### DIFF
--- a/src/services/RecordService.ts
+++ b/src/services/RecordService.ts
@@ -1,9 +1,10 @@
-import Client              from '@/Client';
 import Record              from '@/models/Record';
 import ExternalAuth        from '@/models/ExternalAuth';
 import ListResult          from '@/models/utils/ListResult';
 import CrudService         from '@/services/utils/CrudService';
 import { UnsubscribeFunc } from '@/services/RealtimeService';
+
+import Client, { SendOptions } from '@/Client';
 import {
     BaseQueryParams,
     RecordQueryParams,
@@ -102,7 +103,7 @@ export default class RecordService extends CrudService<Record> {
     async subscribe<T = Record>(topic: string, callback: (data: RecordSubscription<T>) => void): Promise<UnsubscribeFunc>
 
     async subscribe<T = Record>(
-        topicOrCallback: string|((data: RecordSubscription<T>) => void),
+        topicOrCallback: string | ((data: RecordSubscription<T>) => void),
         callback?: (data: RecordSubscription<T>) => void
     ): Promise<UnsubscribeFunc> {
         if (typeof topicOrCallback === 'function') {
@@ -154,45 +155,73 @@ export default class RecordService extends CrudService<Record> {
     /**
      * @inheritdoc
      */
-    getFullList<T = Record>(queryParams?: RecordFullListQueryParams): Promise<Array<T>>
+    getFullList<T = Record>(
+        queryParams?: RecordFullListQueryParams,
+        extraSendOptions?: SendOptions
+    ): Promise<Array<T>>;
 
     /**
      * @inheritdoc
      */
-    getFullList<T = Record>(batch?: number, queryParams?: RecordListQueryParams): Promise<Array<T>>
+    getFullList<T = Record>(
+        batch?: number,
+        queryParams?: RecordListQueryParams,
+        extraSendOptions?: SendOptions
+    ): Promise<Array<T>>;
 
     /**
      * @inheritdoc
      */
-    getFullList<T = Record>(batchOrQueryParams?: number|RecordFullListQueryParams, queryParams?: RecordListQueryParams): Promise<Array<T>> {
+    getFullList<T = Record>(
+        batchOrQueryParams?: number | RecordFullListQueryParams,
+        queryParams?: RecordListQueryParams,
+        extraSendOptions?: SendOptions
+    ): Promise<Array<T>> {
         if (typeof batchOrQueryParams == "number") {
-            return super.getFullList<T>(batchOrQueryParams, queryParams);
+            return super.getFullList<T>(
+                batchOrQueryParams,
+                queryParams,
+                extraSendOptions
+            );
         }
 
         const params = Object.assign({}, batchOrQueryParams, queryParams);
 
-        return super.getFullList<T>(params);
+        return super.getFullList<T>(params, extraSendOptions);
     }
 
     /**
      * @inheritdoc
      */
-    getList<T = Record>(page = 1, perPage = 30, queryParams: RecordListQueryParams = {}): Promise<ListResult<T>> {
-        return super.getList<T>(page, perPage, queryParams);
+    getList<T = Record>(
+        page = 1,
+        perPage = 30,
+        queryParams: RecordListQueryParams = {},
+        extraSendOptions?: SendOptions
+    ): Promise<ListResult<T>> {
+        return super.getList<T>(page, perPage, queryParams, extraSendOptions);
     }
 
     /**
      * @inheritdoc
      */
-    getFirstListItem<T = Record>(filter: string, queryParams: RecordListQueryParams = {}): Promise<T> {
-        return super.getFirstListItem<T>(filter, queryParams);
+    getFirstListItem<T = Record>(
+        filter: string,
+        queryParams: RecordListQueryParams = {},
+        extraSendOptions?: SendOptions
+    ): Promise<T> {
+        return super.getFirstListItem<T>(filter, queryParams, extraSendOptions);
     }
 
     /**
      * @inheritdoc
      */
-    getOne<T = Record>(id: string, queryParams: RecordQueryParams = {}): Promise<T> {
-        return super.getOne<T>(id, queryParams);
+    getOne<T = Record>(
+        id: string,
+        queryParams: RecordQueryParams = {},
+        extraSendOptions?: SendOptions
+    ): Promise<T> {
+        return super.getOne<T>(id, queryParams, extraSendOptions);
     }
 
     /**
@@ -337,11 +366,13 @@ export default class RecordService extends CrudService<Record> {
             'createData':  createData,
         }, bodyParams);
 
-        return this.client.send(this.baseCollectionPath + '/auth-with-oauth2', {
-            'method':  'POST',
-            'params':  queryParams,
-            'body':    bodyParams,
-        }).then((data) => this.authResponse<T>(data));
+        return this.client
+            .send(this.baseCollectionPath + "/auth-with-oauth2", {
+                method: "POST",
+                params: queryParams,
+                body: bodyParams,
+            })
+            .then((data) => this.authResponse<T>(data));
     }
 
     /**

--- a/src/services/utils/CrudService.ts
+++ b/src/services/utils/CrudService.ts
@@ -6,6 +6,7 @@ import {
     ListQueryParams,
     FullListQueryParams
 } from '@/services/utils/QueryParams';
+import { SendOptions } from "@/Client";
 
 export default abstract class CrudService<M extends BaseModel> extends BaseCrudService<M> {
     /**
@@ -19,21 +20,41 @@ export default abstract class CrudService<M extends BaseModel> extends BaseCrudS
      *
      * You can use the generic T to supply a wrapper type of the crud model.
      */
-    getFullList<T = M>(queryParams?: FullListQueryParams): Promise<Array<T>>
+    getFullList<T = M>(
+        queryParams?: FullListQueryParams,
+        extraSendOptions?: SendOptions
+    ): Promise<Array<T>>;
 
     /**
      * Legacy version of getFullList with explicitly specified batch size.
      */
-    getFullList<T = M>(batch?: number, queryParams?: ListQueryParams): Promise<Array<T>>
+    getFullList<T = M>(
+        batch?: number,
+        queryParams?: ListQueryParams,
+        extraSendOptions?: SendOptions
+    ): Promise<Array<T>>;
 
-    getFullList<T = M>(batchOrqueryParams?: number|FullListQueryParams, queryParams?: ListQueryParams): Promise<Array<T>> {
+    getFullList<T = M>(
+        batchOrqueryParams?: number | FullListQueryParams,
+        queryParams?: ListQueryParams,
+        extraSendOptions?: SendOptions
+    ): Promise<Array<T>> {
         if (typeof batchOrqueryParams == "number") {
-            return this._getFullList<T>(this.baseCrudPath, batchOrqueryParams, queryParams);
+            return this._getFullList<T>(
+                this.baseCrudPath,
+                batchOrqueryParams,
+                queryParams,
+                extraSendOptions
+            );
         }
 
         const params = Object.assign({}, batchOrqueryParams, queryParams);
 
-        return this._getFullList<T>(this.baseCrudPath, params.batch || 200, params);
+        return this._getFullList<T>(
+            this.baseCrudPath,
+            params.batch || 200,
+            params
+        );
     }
 
     /**
@@ -41,8 +62,19 @@ export default abstract class CrudService<M extends BaseModel> extends BaseCrudS
      *
      * You can use the generic T to supply a wrapper type of the crud model.
      */
-    getList<T = M>(page = 1, perPage = 30, queryParams: ListQueryParams = {}): Promise<ListResult<T>> {
-        return this._getList<T>(this.baseCrudPath, page, perPage, queryParams);
+    getList<T = M>(
+        page = 1,
+        perPage = 30,
+        queryParams: ListQueryParams = {},
+        extraSendOptions: SendOptions = {}
+    ): Promise<ListResult<T>> {
+        return this._getList<T>(
+            this.baseCrudPath,
+            page,
+            perPage,
+            queryParams,
+            extraSendOptions
+        );
     }
 
     /**
@@ -56,8 +88,17 @@ export default abstract class CrudService<M extends BaseModel> extends BaseCrudS
      * For consistency with `getOne`, this method will throw a 404
      * ClientResponseError if no item was found.
      */
-    getFirstListItem<T = M>(filter: string, queryParams: BaseQueryParams = {}): Promise<T> {
-        return this._getFirstListItem<T>(this.baseCrudPath, filter, queryParams);
+    getFirstListItem<T = M>(
+        filter: string,
+        queryParams: BaseQueryParams = {},
+        extraSendOptions: SendOptions = {}
+    ): Promise<T> {
+        return this._getFirstListItem<T>(
+            this.baseCrudPath,
+            filter,
+            queryParams,
+            extraSendOptions
+        );
     }
 
     /**
@@ -65,8 +106,17 @@ export default abstract class CrudService<M extends BaseModel> extends BaseCrudS
      *
      * You can use the generic T to supply a wrapper type of the crud model.
      */
-    getOne<T = M>(id: string, queryParams: BaseQueryParams = {}): Promise<T> {
-        return this._getOne<T>(this.baseCrudPath, id, queryParams);
+    getOne<T = M>(
+        id: string,
+        queryParams: BaseQueryParams = {},
+        extraSendOptions: SendOptions = {}
+    ): Promise<T> {
+        return this._getOne<T>(
+            this.baseCrudPath,
+            id,
+            queryParams,
+            extraSendOptions
+        );
     }
 
     /**


### PR DESCRIPTION
This add the possibility to pass extra options to the final fetch request, on get methods.

Use case: we will be able to fine-grain the behavior of each request, for example the `cache` or the NextJS 13 `next` keys.
NextJS being a big part of the web, it will allow us to take full control on their [revalidation workflow](https://beta.nextjs.org/docs/data-fetching/revalidating)

Sidenote: I've seen that you don't have any prettier or eslint config, nor CI to run lint/tests on PR, that gave me trouble to not bring any useless line-changes. Is this a wanted behavior or just lack of time to setup ?