### PR TITLE
feat: update realtime and record services to subscribe synchronously

### DIFF
--- a/src/services/RealtimeService.ts
+++ b/src/services/RealtimeService.ts
@@ -40,7 +40,7 @@ export default class RealtimeService extends BaseService {
      * If the SSE connection is not started yet,
      * this method will also initialize it.
      */
-    async subscribe(topic: string, callback: (data: any) => void): Promise<UnsubscribeFunc> {
+    subscribe(topic: string, callback: (data: any) => void): UnsubscribeFunc {
         if (!topic) {
             throw new Error('topic must be set.')
         }
@@ -64,10 +64,10 @@ export default class RealtimeService extends BaseService {
 
         if (!this.isConnected) {
             // initialize sse connection
-            await this.connect();
+            this.connect();
         } else if (this.subscriptions[topic].length === 1) {
             // send the updated subscriptions (if it is the first for the topic)
-            await this.submitSubscriptions();
+            this.submitSubscriptions();
         } else {
             // only register the listener
             this.eventSource?.addEventListener(topic, listener);

--- a/src/services/RecordService.ts
+++ b/src/services/RecordService.ts
@@ -122,12 +122,12 @@ export default class RecordService extends CrudService<Record> {
      * You can use the returned `UnsubscribeFunc` to remove only a single subscription.
      * Or use `unsubscribe(topic)` if you want to remove all subscriptions attached to the topic.
      */
-    async subscribe<T = Record>(topic: string, callback: (data: RecordSubscription<T>) => void): Promise<UnsubscribeFunc>
+    subscribe<T = Record>(topic: string, callback: (data: RecordSubscription<T>) => void): UnsubscribeFunc
 
-    async subscribe<T = Record>(
+    subscribe<T = Record>(
         topicOrCallback: string|((data: RecordSubscription<T>) => void),
         callback?: (data: RecordSubscription<T>) => void
-    ): Promise<UnsubscribeFunc> {
+    ): UnsubscribeFunc {
         if (typeof topicOrCallback === 'function') {
             console.warn("PocketBase: subscribe(callback) is deprecated. Please replace it with subscribe('*', callback).");
             return this.client.realtime.subscribe(this.collectionIdOrName, topicOrCallback);


### PR DESCRIPTION
## Description

This updates both realtime and record services to handle subscriptions synchronously, giving the client a callback when a collection is subscribed to. More details about the problem in [this issue](https://github.com/pocketbase/js-sdk/issues/215).

## Issue

https://github.com/pocketbase/js-sdk/issues/215
