### PR TITLE
feat: add Client to named export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,5 @@ export * from '@/stores/AsyncAuthStore';
 export * from '@/stores/utils/jwt';
 export * from '@/stores/utils/cookie';
 
+export { Client }
 export default Client;


### PR DESCRIPTION
This will allow importing `Client` not as default
```ts
import { Client } from "pocketbase"
```
This empowers users who prefer to avoid default exports and allows typing a client through a module declaration instead of interface casting

Solves #263 