### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ export const onRequest = defineMiddleware(async ({ locals, request }: any, next:
     const response = await next();
 
     // send back the default 'pb_auth' cookie to the client with the latest store state
-    response.headers.append('set-cookie', locals.pb.authStore.exportToCookie());
+    response.headers.append('set-cookie', locals.pb.authStore.exportToCookie({ httpOnly: false, secure: !!import.meta.env.PROD }));
 
     return response;
 });


### PR DESCRIPTION
Astro provides import.meta.env.PROD value out of the box. I believe the Astro example can be tweaked to avoid this problem: 

https://github.com/pocketbase/pocketbase/discussions/3478

secure is set to false in DEV environment, and true in PROD.