### PR TITLE
[#294] Link d.ts file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "main": "./dist/pocketbase.es.mjs",
     "module": "./dist/pocketbase.es.mjs",
     "react-native": "./dist/pocketbase.es.js",
-    "types": "./dist/pocketbase.es.d.mts",
+    "types": "./dist/pocketbase.es.d.ts",
     "keywords": [
         "pocketbase",
         "pocketbase-js",
@@ -38,6 +38,7 @@
     },
     "devDependencies": {
         "@rollup/plugin-terser": "^0.4.3",
+        "@types/node": "^20.14.2",
         "prettier": "3.2.4",
         "rollup": "^3.0.0",
         "rollup-plugin-ts": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,10 @@
         "url": "git://github.com/pocketbase/js-sdk.git"
     },
     "exports": {
-        ".": "./dist/pocketbase.es.mjs",
+        ".": "./dist/pocketbase.cjs.js",
         "./cjs": "./dist/pocketbase.cjs.js",
         "./umd": "./dist/pocketbase.umd.js"
     },
-    "main": "./dist/pocketbase.es.mjs",
     "module": "./dist/pocketbase.es.mjs",
     "react-native": "./dist/pocketbase.es.js",
     "types": "./dist/pocketbase.es.d.ts",


### PR DESCRIPTION
Change to `d.ts` so that Typescript / Node doesn't get confused by the `d.mts` extension.

Also, install `@types/node` as a devDependency. Without node typings, `src/stores/utils/jwt.ts` will not build because the type definition for `global` is missing.