### PR TITLE
fix: Subscribe's Option Type missing fields for RecordOptions

### DIFF
--- a/src/services/RecordService.ts
+++ b/src/services/RecordService.ts
@@ -117,7 +117,7 @@ export class RecordService<M = RecordModel> extends CrudService<M> {
     async subscribe<T = M>(
         topic: string,
         callback: (data: RecordSubscription<T>) => void,
-        options?: SendOptions,
+        options?: RecordOptions,
     ): Promise<UnsubscribeFunc> {
         if (!topic) {
             throw new Error("Missing topic.");


### PR DESCRIPTION
When you attempt to add options like expand to a subscribe operation, the type makes you think that subscribe does not support expand, even when support for it is detailed in the [documentation](https://pocketbase.io/docs/api-realtime/).

The fix was to simply match the optionType of subscribe to the one for record requests. Changing locally this field in the outputted `pocketbase.es.d.mts` file seemed to work, so I simply changed the origin's file.

**Needs review**
Because subscribe also allows you to subscribe to an entire collection aswell, I'm unsure if additional changes are needed.