### PR TITLE
fix: is not null check in serializeQueryParams

### DIFF
--- a/src/tools/options.ts
+++ b/src/tools/options.ts
@@ -167,7 +167,7 @@ export function serializeQueryParams(params: { [key: string]: any }): string {
             }
         } else if (value instanceof Date) {
             result.push(encodedKey + "=" + encodeURIComponent(value.toISOString()));
-        } else if (typeof value !== null && typeof value === "object") {
+        } else if (value !== null && typeof value === "object") {
             result.push(encodedKey + "=" + encodeURIComponent(JSON.stringify(value)));
         } else {
             result.push(encodedKey + "=" + encodeURIComponent(value));


### PR DESCRIPTION
Hello Gani,

this PR only changes a minor issue in the `serializeQueryParams` function in this part:
```
        } else if (value !== null && typeof value === "object") {
```

`typeof value !== null` always evaluates to `true` because the typeof operator always returns a string. So if `value` really is `null` encodeURIComponent(JSON.stringify(value)) will encode `"null"`

I noticed that there are no unit test for `serializeQueryParams` itself. Should I add unit tests in order to support this PR?

