### PR TITLE
Fix unit tests when run in Ireland

### DIFF
--- a/tests/Client.spec.ts
+++ b/tests/Client.spec.ts
@@ -202,7 +202,7 @@ describe("Client", function () {
                 test5: 123,
                 test6: -123.45,
                 test7: 123.45,
-                test8: new Date("2023-10-18 10:11:12"),
+                test8: new Date("2023-10-18 10:11:12+0300"),
                 test9: [1, 2, 3, "test'123"],
                 test10: { a: "test'123" },
             };


### PR DESCRIPTION

`new Date(...)` without specifying a timezone appears to default to the user's timezone, so 10am (specified in the test input) equals 7am (specified in the test output)... _if_ the user lives in a UTC+0300 country. If these tests are run from a different country, the test fails. Setting an explicit timezone on the input means that tests should now pass no matter what country they are run in :)
