### PR TITLE
Type "expand" in RecordService CRUD methods

### DIFF
--- a/src/tools/dtos.ts
+++ b/src/tools/dtos.ts
@@ -20,10 +20,10 @@ export interface LogModel extends BaseModel {
     data: { [key: string]: any };
 }
 
-export interface RecordModel extends BaseModel {
+export interface RecordModel<TExpand = ExpandMap> extends BaseModel {
     collectionId: string;
     collectionName: string;
-    expand?: { [key: string]: any };
+    expand?: TExpand;
 }
 
 // -------------------------------------------------------------------
@@ -137,3 +137,9 @@ export type CollectionModel =
     | BaseCollectionModel
     | ViewCollectionModel
     | AuthCollectionModel;
+
+export type Expand<T> = {
+    expand: T;
+};
+
+export type ExpandMap = Record<string, RecordModel | RecordModel[]>;

--- a/src/tools/options.ts
+++ b/src/tools/options.ts
@@ -64,13 +64,17 @@ export interface FullListOptions extends ListOptions {
     batch?: number;
 }
 
-export interface RecordOptions extends CommonOptions {
-    expand?: string;
+export interface RecordOptions<TExpand extends string = string> extends CommonOptions {
+    expand?: TExpand;
 }
 
-export interface RecordListOptions extends ListOptions, RecordOptions {}
+export interface RecordListOptions<TExpand extends string = string>
+    extends ListOptions,
+        RecordOptions<TExpand> {}
 
-export interface RecordFullListOptions extends FullListOptions, RecordOptions {}
+export interface RecordFullListOptions<TExpand extends string = string>
+    extends FullListOptions,
+        RecordOptions<TExpand> {}
 
 export interface RecordSubscribeOptions extends SendOptions {
     fields?: string;

--- a/src/tools/type-utils.ts
+++ b/src/tools/type-utils.ts
@@ -1,0 +1,7 @@
+export type Join<T extends string> = T | `${T},${T}`;
+
+export type Split<T> = T extends `${infer U},${infer V}` ? [U, ...Split<V>] : [T];
+
+export type PickCommaSeparated<T extends Record<string, unknown>, K extends string> = {
+    [TKey in Split<K>[number]]: T[TKey];
+};


### PR DESCRIPTION
Hi!

This PR allows to type relationships between models when using `RecordService`

This would allow [pocketbase-typegen](https://github.com/patmood/pocketbase-typegen) to generate something like this:

```ts
export type TypedPocketBase = PocketBase & {
  collection(idOrName: "authors"): RecordService<AuthorsResponse>;
  collection(idOrName: "chapters"): RecordService<ChaptersResponse>;
  collection(idOrName: "courses"): RecordService<
    CoursesResponse,
    {
      author: AuthorsResponse;
      chapters_via_course: ChaptersResponse[];
    }
  >;
}
```

And have it nicely Typed:

<img width="697" height="295" alt="image" src="https://github.com/user-attachments/assets/0002dada-e741-4529-bd8a-2a408b36755a" />

It would also hint possible comma separated expand fields (unfortunately with duplicates I couldn't solve this one):

<img width="696" height="167" alt="image" src="https://github.com/user-attachments/assets/04a22733-830b-4fe2-a460-b24650415682" />
