### PR TITLE
fixes options type of `authWithPassword`

### DIFF
--- a/src/services/RecordService.ts
+++ b/src/services/RecordService.ts
@@ -12,6 +12,7 @@ import {
     RecordOptions,
     SendOptions,
     RecordSubscribeOptions,
+    AuthOptions,
 } from "@/tools/options";
 import { getTokenPayload } from "@/tools/jwt";
 import { registerAutoRefresh, resetAutoRefresh } from "@/tools/refresh";
@@ -358,7 +359,7 @@ export class RecordService<M = RecordModel> extends CrudService<M> {
     async authWithPassword<T = M>(
         usernameOrEmail: string,
         password: string,
-        options?: RecordOptions,
+        options?: AuthOptions,
     ): Promise<RecordAuthResponse<T>> {
         options = Object.assign(
             {

--- a/src/tools/options.ts
+++ b/src/tools/options.ts
@@ -87,7 +87,7 @@ export interface FileOptions extends CommonOptions {
     download?: boolean;
 }
 
-export interface AuthOptions extends CommonOptions {
+export interface AuthOptions extends RecordOptions {
     /**
      * If autoRefreshThreshold is set it will take care to auto refresh
      * when necessary the auth data before each request to ensure that


### PR DESCRIPTION
I'm using `collection("_superusers").authWithPassword` in a backend application and noticed that `authRefreshThreshold` isn't included in the types. I'm not sure what your plans are regarding the auto refresh feature, as [I saw a note in the code suggesting it might be deprecated in the future](https://github.com/pocketbase/js-sdk/blob/e87b2ff95fe70b19881e240090d835a0031a334d/src/services/RecordService.ts#L374C9-L374C39). However, for now, I suggest this small fix to slightly improve the dx. 

Thank you for this awesome project!