### PR TITLE
fix: detect abort errors in React Native environments

### DIFF
--- a/src/ClientResponseError.ts
+++ b/src/ClientResponseError.ts
@@ -44,6 +44,12 @@ export class ClientResponseError extends Error {
             this.isAbort = true;
         }
 
+        // In React Native, aborting a fetch throws a plain Error with message "Aborted"
+        // instead of a DOMException, so we need to detect it by message content.
+        if (errData?.message === "Aborted") {
+            this.isAbort = true;
+        }
+
         this.name = "ClientResponseError " + this.status;
         this.message = this.response?.message;
         if (!this.message) {

--- a/tests/ClientResponseError.spec.ts
+++ b/tests/ClientResponseError.spec.ts
@@ -85,5 +85,18 @@ describe("ClientResponseError", function () {
             assert.equal(err.originalError, err0);
             assert.include(err.message, "request was autocancelled");
         });
+
+        // React Native throws a plain Error with message "Aborted" instead of DOMException
+        test("with React Native abort error", function () {
+            const err0 = new Error("Aborted");
+            const err = new ClientResponseError(err0);
+
+            assert.equal(err.url, "");
+            assert.equal(err.status, 0);
+            assert.deepEqual(err.response, {});
+            assert.equal(err.isAbort, true);
+            assert.equal(err.originalError, err0);
+            assert.include(err.message, "request was autocancelled");
+        });
     });
 });


### PR DESCRIPTION
In browser environments, aborting a fetch request throws a DOMException with name "AbortError". However, in React Native (using Hermes or other JS engines), the abort throws a plain Error with the message "Aborted".  This is an issue because the PocketBaseJS itself aborts connections when 'auto-cancellation' is enabled.

The current abort detection only checks for DOMException, causing React Native apps to receive "Something went wrong." errors instead of the proper autocancellation message when requests are cancelled.

This change adds detection for the React Native abort pattern by also checking if errData.message === "Aborted".

This may also fix the issue described in https://github.com/pocketbase/js-sdk/issues/114